### PR TITLE
Add support for running within docker container via docker-compose

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+FROM python:3.6
+ENV PYTHONUNBUFFERED 1
+
+# Install Dockerize
+RUN apt-get update && apt-get install -y wget
+ENV DOCKERIZE_VERSION v0.6.1
+RUN wget https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz \
+    && tar -C /usr/local/bin -xzvf dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz \
+    && rm dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz
+
+# Copy current dir (AIhome) into container /code
+RUN mkdir /code
+WORKDIR /code
+COPY . /code/
+RUN python3 -m pip install -r requirements.txt
+CMD dockerize python ./wsgi.py

--- a/README.md
+++ b/README.md
@@ -37,6 +37,15 @@ or
 To log in the default is **admin/admin**
 You can change the password inside the web console
 
+# Docker using docker-compose
+To run this within a Docker container, ignore above installation and running, and instead:
+- If docker-compose is not already installed, install docker-compose see: https://docs.docker.com/compose/install/
+- Update docker-compose.yml
+  - MQTT_BROKER_URL in docker-compose.yml to point at your broker.
+  - optionally change which port you want this app to be served on your host in (default 9000)
+- In this directory do: ```docker-compose up --build```
+- In a browser on your host, go to http://localhost:9000 or whatever port you configured.
+
 # Information
 
 As you start using your devices around the house, the system will start to build a list of sites and the logs will start to grow

--- a/config.py
+++ b/config.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python3
 # -*- coding:utf-8 -*-
 
+import os
+
 ### **************************************************************************** ###
 ### Only change these setting for your setup
 ### **************************************************************************** ###
@@ -8,16 +10,16 @@
 # Port to run site on
 PORT = 80
 
-#Theme 
+#Theme
 #set inside the website settings from the top menu bar
 
 # MQTT
-MQTT_BROKER_URL = '10.0.1.100'  # broker url
-MQTT_BROKER_PORT = 1883  # default port for non-tls connection
+MQTT_BROKER_URL = os.getenv('MQTT_BROKER_URL')  # broker url
+MQTT_BROKER_PORT = int(os.getenv('MQTT_BROKER_PORT', 1883))  # default port for non-tls connection
 MQTT_USERNAME = ''  # set the username here if you need authentication for the broker
 MQTT_PASSWORD = ''  # set the password here if the broker demands authentication
 MQTT_KEEPALIVE = 60  # set the time interval for sending a ping to the broker to 5 seconds
-MQTT_TLS_ENABLED = False  
+MQTT_TLS_ENABLED = False
 
 
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,39 @@
+# Requirements:
+#  - docker-compose see: https://docs.docker.com/compose/install/ & https://docs.docker.com/compose/reference/
+# Builds and start a container in foreground allowing you to stop it via <CTRL><C>
+# NOTE: while stopped, any SNIPS activity across MQTT will be missing from watch log and overview stats.
+#  - docker-compose up --build
+# Build and start container detached. Use "docker-compose stop" to shut it down.
+#  - docker-compose up --build --detach
+# Stop container maintaining existing history
+#  - docker-compose stop
+#
+# Useful commands:
+#  To get shell within container (if container is already running, substitute "run" with "exec"
+#   - docker-compose run aihome bash
+#  To run python within container
+#   - docker-compose run aihome python
+#
+# TODO:
+# - To maintain history across builds, consider adding volumes, see docker-compose:
+#   https://docs.docker.com/compose/compose-file/#volumes
+
+version: "3.7"
+x-default: &default-env
+  environment:
+    # Change these to your MQTT broker, read by config.py
+    MQTT_BROKER_URL:  "192.168.0.13"
+    MQTT_BROKER_PORT: 1883
+services:
+  aihome:
+    <<: *default-env
+    build: .
+    ports:
+      # Remap container port 80 to your host machine.
+      # e.g. 9000:80 lets you access this container via url via http://localhost:9000/watch
+      - "9000:80"
+    init: true
+    # Uncomment the following and you container will always be restarted if it fails and across system reboots.
+    # This avoids having to do a compose-dev up each time, only initially when initially built or rebuilt.
+    #
+    # restart: always


### PR DESCRIPTION
- change: config.py to use getenv for MQTT_BROKER_URL & MQTT_BROKER_PORT
- add: docker-compose.yml
- add: Dockerfile
- change: add section to README.md